### PR TITLE
FVTT v9 update + bugfixes + minor upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ As requested by the Japanese community
 - Added `Formula Persistance` module setting for configuring if the roller should remain after a roll
 - Fixed `Roller Persistance` module setting that was present but not working
 - Fixed a bug that prevented the Roll button to work on the first click after changing the formula input
+- Fixed a bug that prevented headers `### ■` that had no header trim values from working.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BCRoller
 
-![Foundry Version Compatability](https://img.shields.io/badge/Foundry-v0.8.7-informational)
+![Foundry Version Compatibility](https://img.shields.io/badge/Foundry-v9-informational)
 ![Latest Release Download Count](https://img.shields.io/github/downloads/jsinme/fvtt-bcdice/latest/module.zip)
 
 A module to query the BCDice API for dice rolls. BCDice is the largest dice rolling bot in Japan, containing 100s of different TRPG systems and playstyles.　You can find the sourcecode [here](https://github.com/bcdice/BCDice). Please feel free to join their Discord and discuss your favorite Japanese TRPGs. You can even submit localization files for them.
@@ -17,13 +17,13 @@ https://foundryvtt.wiki/ja/home
 
 ## Changelog
 
-0.1
+### 0.1
 
 - BCDice Control in left controls bar
 - Roller Application that allows a user to select from a list of available systems, input a command, and submit that command to the api
 - Chat Message containing result fo the roll
 
-  0.2
+### 0.2
 
 - Added keyboard shortcut for launching Roller (Ctrl + Shift + B)
 - Browser will focus on the command input field when Roller is brought up
@@ -32,16 +32,16 @@ https://foundryvtt.wiki/ja/home
 - Roller will now remember the last selected game system when reopened
 - Result chat message will now also contain the original command below the result
 
-  0.2.1
+### 0.2.1
 
 - Added help button to get info on a System
 - Added a sound to be played when a roll occurs
 
-  0.2.2
+### 0.2.2
 
 - Fixed formatting for System help messages
 
-  0.2.3
+### 0.2.3
 
 - Changed dice rolling sound to native foundry sound
 - Special characters in commands are now escaped properly
@@ -50,28 +50,37 @@ https://foundryvtt.wiki/ja/home
 - Roller outputs have been reformated for clarity
 - Added link to bcdice docs at the top of each System help message
 
-  0.2.4
+### 0.2.4
 
 - Added localization for Japanese
 
-  0.3 Dice So Nice!
+### 0.3 Dice So Nice!
 
 - Added support for DSN
 
-  0.4
+### 0.4
 
 - Added System Search
 - Added Secret Roll Support
 - Added Roller Persistance setting
 - Bug Fixes
 
-  2.0.0
+### 2.0.0
 
 - Added one-line macro support by Spice King
 
-  2.0.1
+### 2.0.1
 
 - removed system name from the chat message that contains the commands
 - removed system name from the BCdice response, made that into the chat card alias instead
 - removed the error message when command is not found
 As requested by the Japanese community
+
+### 3.0.0 - V9 compatibility
+
+- Upping mayor version as this is not backward-compatible with versions < V9
+- Fixed sidebar icon
+- Updated keybindings to use the new Keybindings API
+- Added `Formula Persistance` module setting for configuring if the roller should remain after a roll
+- Fixed `Roller Persistance` module setting that was present but not working
+- Fixed a bug that prevented the Roll button to work on the first click after changing the formula input

--- a/README.md
+++ b/README.md
@@ -83,5 +83,10 @@ As requested by the Japanese community
 - Updated keybindings to use the new Keybindings API
 - Added `Formula Persistance` module setting for configuring if the roller should remain after a roll
 - Fixed `Roller Persistance` module setting that was present but not working
-- Fixed a bug that prevented the Roll button to work on the first click after changing the formula input
-- Fixed a bug that prevented headers `### ■` that had no header trim values from working.
+- Bugfix that prevented the Roll button to work on the first click after changing the formula input
+- Bugfix that prevented headers `### ■` that had no header trim values from working.
+
+### 3.0.1
+
+- Bugfix where header line parsing was not using start-of-string `^` nor end-of-string `$` anchors that caused some incorrect parsing
+- Bugfix for importing without any header start nor trim not sending values to Default Header as expected.

--- a/languages/en.json
+++ b/languages/en.json
@@ -34,5 +34,9 @@
   "fvtt-bcdice.newMacro": "New Macro",
   "fvtt-bcdice.defaultHeader": "Default Header",
   "fvtt-bcdice.addHeader": "Add Header",
-  "fvtt-bcdice.addMacro": "Add Macro"
+  "fvtt-bcdice.addMacro": "Add Macro",
+  "fvtt-bcdice.keybindName": "Open BC Dice Roller",
+  "fvtt-bcdice.keybindHint": "This is a hint for the keybinding",
+  "fvtt-bcdice.formulaPersistanceSettingName": "Formula Persistance",
+  "fvtt-bcdice.formulaPersistanceSettingHint": "Should the formula in the text input stay after pressing Enter / Roll?"
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -36,7 +36,7 @@
   "fvtt-bcdice.addHeader": "Add Header",
   "fvtt-bcdice.addMacro": "Add Macro",
   "fvtt-bcdice.keybindName": "Open BC Dice Roller",
-  "fvtt-bcdice.keybindHint": "This is a hint for the keybinding",
+  "fvtt-bcdice.keybindHint": "This keybind will open the BCDice Roller, as an alternative to the sidebar button",
   "fvtt-bcdice.formulaPersistanceSettingName": "Formula Persistance",
   "fvtt-bcdice.formulaPersistanceSettingHint": "Should the formula in the text input stay after pressing Enter / Roll?"
 }

--- a/languages/ja.json
+++ b/languages/ja.json
@@ -34,5 +34,9 @@
   "fvtt-bcdice.newMacro": "新規マクロ",
   "fvtt-bcdice.defaultHeader": "デフォルトヘッダ",
   "fvtt-bcdice.addHeader": "ヘッダ追加",
-  "fvtt-bcdice.addMacro": "マクロ追加"
+  "fvtt-bcdice.addMacro": "マクロ追加",
+  "fvtt-bcdice.keybindName": "Open BC Dice Roller",
+  "fvtt-bcdice.keybindHint": "This is a hint for the keybinding",
+  "fvtt-bcdice.formulaPersistanceSettingName": "Formula Persistance",
+  "fvtt-bcdice.formulaPersistanceSettingHint": "Should the formula in the text input stay after pressing Enter / Roll?"
 }

--- a/languages/ja.json
+++ b/languages/ja.json
@@ -35,8 +35,8 @@
   "fvtt-bcdice.defaultHeader": "デフォルトヘッダ",
   "fvtt-bcdice.addHeader": "ヘッダ追加",
   "fvtt-bcdice.addMacro": "マクロ追加",
-  "fvtt-bcdice.keybindName": "Open BC Dice Roller",
-  "fvtt-bcdice.keybindHint": "This is a hint for the keybinding",
-  "fvtt-bcdice.formulaPersistanceSettingName": "Formula Persistance",
-  "fvtt-bcdice.formulaPersistanceSettingHint": "Should the formula in the text input stay after pressing Enter / Roll?"
+  "fvtt-bcdice.keybindName": "BCダイス・チャットパレットを開く",
+  "fvtt-bcdice.keybindHint": "BCダイスを使うためのメニューとチャットパレットを登録するための画面を開きます。",
+  "fvtt-bcdice.formulaPersistanceSettingName": "ロール式維持",
+  "fvtt-bcdice.formulaPersistanceSettingHint": "ロール後に入力欄に前のコマンドを残しますか？"
 }

--- a/module.json
+++ b/module.json
@@ -5,8 +5,8 @@
   "version": "This is auto replaced",
   "library": "false",
   "manifestPlusVersion": "1.0.0",
-  "minimumCoreVersion": "0.7.9",
-  "compatibleCoreVersion": "0.8.7",
+  "minimumCoreVersion": "9.249",
+  "compatibleCoreVersion": "9.249",
   "authors": [
     {
       "name": "Jason",

--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
   "version": "This is auto replaced",
   "library": "false",
   "manifestPlusVersion": "1.0.0",
-  "minimumCoreVersion": "9.249",
+  "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9.249",
   "authors": [
     {

--- a/scripts/bcdice-dialog.js
+++ b/scripts/bcdice-dialog.js
@@ -96,8 +96,8 @@ export default class BCDialog extends FormApplication {
     html.find("[data-header] > h3").click(this._headerClick.bind(this));
     html.find("button[data-delete-tab]").click(this._deleteTab.bind(this));
     html
-    .find("button[data-delete-header]")
-    .click(this._deleteHeader.bind(this));
+      .find("button[data-delete-header]")
+      .click(this._deleteHeader.bind(this));
     html.find("a[data-delete-macro]").click(this._deleteMacro.bind(this));
     html.find("button.bcd-macro-button").click(this._macroClick.bind(this));
     html
@@ -204,6 +204,10 @@ export default class BCDialog extends FormApplication {
   _onRollButton() {
     const rollFormula = this.form.querySelector("#bc-formula").value;
     this.roll(rollFormula);
+    const shouldPersistInput = game.settings.get("fvtt-bcdice", "formula-persistance");
+    if (!shouldPersistInput) {
+      document.getElementById("bc-formula").value = '';
+    }
   }
 
   async _deleteTab(event) {

--- a/scripts/bcdice-dialog.js
+++ b/scripts/bcdice-dialog.js
@@ -201,12 +201,17 @@ export default class BCDialog extends FormApplication {
       .macro;
   }
 
-  _onRollButton() {
+  _onRollButton(ev) {
     const rollFormula = this.form.querySelector("#bc-formula").value;
     this.roll(rollFormula);
     const shouldPersistInput = game.settings.get("fvtt-bcdice", "formula-persistance");
     if (!shouldPersistInput) {
-      document.getElementById("bc-formula").value = '';
+      this.form.querySelector("#bc-formula").value = '';
+    }
+
+    const shouldPersistRoller = game.settings.get("fvtt-bcdice", "roller-persistance");
+    if (ev.shiftKey || !shouldPersistRoller) {
+      this.close();
     }
   }
 
@@ -441,7 +446,7 @@ export default class BCDialog extends FormApplication {
     if (event.key === "Enter") {
       event.preventDefault();
       event.stopPropagation();
-      this._onRollButton();
+      this._onRollButton(event);
     }
   }
 }

--- a/scripts/bcdice-dialog.js
+++ b/scripts/bcdice-dialog.js
@@ -1,5 +1,5 @@
 import {
-  getCurrentEntity,
+  getCurrentDocument,
   getDataForCurrentEntity,
   roll,
 } from "./dsn-utilities.js";
@@ -64,12 +64,12 @@ export default class BCDialog extends FormApplication {
 
   async getData() {
     const macros = getDataForCurrentEntity();
-    const entity = getCurrentEntity();
+    const entity = getCurrentDocument();
     return {
       editing: this.options.isEditable ?? false,
       systems: await getSystems(),
       data: macros,
-      type: entity.constructor.name,
+      type: entity.constructor.documentName,
       entity: entity,
     };
   }
@@ -431,9 +431,8 @@ export default class BCDialog extends FormApplication {
     const tabs = formData.tabs || getDataForCurrentEntity().tabs;
     const data = mergeObject(getDataForCurrentEntity(), expandObject(formData));
     data.tabs = tabs;
-    await getCurrentEntity().setFlag("fvtt-bcdice", "macro-data", data);
-    // this._render();
-    // FIXME this _render is causing an onChange event to be fired on the input that prevents the Roll button to work unless you unselect the input first and trigger the onChange event manually
+    await getCurrentDocument().setFlag("fvtt-bcdice", "macro-data", data);
+    this._render();
   }
 
   _onKeyDown(event) {

--- a/scripts/bcdice-dialog.js
+++ b/scripts/bcdice-dialog.js
@@ -432,7 +432,8 @@ export default class BCDialog extends FormApplication {
     const data = mergeObject(getDataForCurrentEntity(), expandObject(formData));
     data.tabs = tabs;
     await getCurrentEntity().setFlag("fvtt-bcdice", "macro-data", data);
-    this._render();
+    // this._render();
+    // FIXME this _render is causing an onChange event to be fired on the input that prevents the Roll button to work unless you unselect the input first and trigger the onChange event manually
   }
 
   _onKeyDown(event) {

--- a/scripts/bcdice.js
+++ b/scripts/bcdice.js
@@ -16,44 +16,60 @@ Hooks.once("init", async () => {
 
   document.head.appendChild(select2Style);
   document.head.appendChild(select2Script);
-});
 
-Hooks.once("ready", async () => {
   roller = await setupRoller();
-  document.addEventListener("keydown", event => {
-    if (event.ctrlKey && event.shiftKey && event.key === "B") showRoller(roller);
-  });
+  registerKeybinds();
 });
 
 Hooks.on("renderSceneControls", async function () {
   if (!$("#bc-dice-control").length) {
-    $("#controls").append('<li class="scene-control" id="bc-dice-control" title="BC Dice"><i class="fas fa-dice"></i></li>');
+    $("#controls > .main-controls").append('<li class="scene-control" id="bc-dice-control" title="BC Dice"><i class="fas fa-dice"></i></li>');
     $("#bc-dice-control").click(() => {
       showRoller(roller);
     });
   }
 });
 
+async function registerKeybinds() {
+  game.keybindings.register("fvtt-bcdice", 'open', {
+    name: game.i18n.localize("fvtt-bcdice.keybindName"),
+    hint: game.i18n.localize("fvtt-bcdice.keybindHint"),
+    editable: [
+      {
+        key: 'KeyB',
+        modifiers: ["Control", "Shift"],
+      },
+    ],
+    onDown: () => {
+      showRoller(roller)
+    },
+    precedence: CONST.KEYBINDING_PRECEDENCE.NORMAL,
+  });
+}
+
 async function registerSettings() {
-  const persistanceSettingName = game.i18n.localize("fvtt-bcdice.persistanceSettingName");
-  const persistanceSettingHint = game.i18n.localize("fvtt-bcdice.persistanceSettingHint");
-  const serverSettingName = game.i18n.localize("fvtt-bcdice.serverSettingName");
-  const serverSettingHint = game.i18n.localize("fvtt-bcdice.serverSettingHint");
-  const systemSettingName = game.i18n.localize("fvtt-bcdice.systemSettingName");
-  const systemSettingHint = game.i18n.localize("fvtt-bcdice.systemSettingHint");
 
   game.settings.register("fvtt-bcdice", "roller-persistance", {
-    name: persistanceSettingName,
-    hint: persistanceSettingHint,
+    name: game.i18n.localize("fvtt-bcdice.persistanceSettingName"),
+    hint: game.i18n.localize("fvtt-bcdice.persistanceSettingHint"),
     scope: "client",
     config: true,
     type: Boolean,
     default: true
   });
 
+  game.settings.register("fvtt-bcdice", "formula-persistance", {
+    name: game.i18n.localize("fvtt-bcdice.formulaPersistanceSettingName"),
+    hint: game.i18n.localize("fvtt-bcdice.formulaPersistanceSettingHint"),
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: false
+  });
+
   game.settings.register("fvtt-bcdice", "bc-server", {
-    name: serverSettingName,
-    hint: serverSettingHint,
+    name: game.i18n.localize("fvtt-bcdice.serverSettingName"),
+    hint: game.i18n.localize("fvtt-bcdice.serverSettingHint"),
     scope: "world",
     config: true,
     type: String,
@@ -68,8 +84,8 @@ async function registerSettings() {
   }, {});
 
   game.settings.register("fvtt-bcdice", "game-system", {
-    name: systemSettingName,
-    hint: systemSettingHint,
+    name: game.i18n.localize("fvtt-bcdice.systemSettingName"),
+    hint: game.i18n.localize("fvtt-bcdice.systemSettingHint"),
     scope: "world",
     config: true,
     type: String,

--- a/scripts/dsn-utilities.js
+++ b/scripts/dsn-utilities.js
@@ -109,18 +109,23 @@ async function roll(system, formula) {
   }
 }
 
-function getCurrentEntity() {
+/**
+ * 
+ * @returns current entity document
+ */
+function getCurrentDocument() {
   if (
     canvas?.tokens?.controlled.length === 1 &&
-    (game.user.isGM || canvas.tokens.controlled[0].actor.permission === 3)
-  )
-    return canvas.tokens.controlled[0];
+    (game.user.isGM || canvas.tokens.controlled[0].actor.permission === CONST.ENTITY_PERMISSION.OWNER)
+  ) {
+    return canvas.tokens.controlled[0].document;
+  }
   return game.user.character ?? game.user;
 }
 
 function getDataForCurrentEntity() {
   return duplicate(
-    getCurrentEntity().getFlag("fvtt-bcdice", "macro-data") ?? {
+    getCurrentDocument().getFlag("fvtt-bcdice", "macro-data") ?? {
       tabs: [],
       importSettings: {},
       replacements: "",
@@ -128,4 +133,4 @@ function getDataForCurrentEntity() {
   );
 }
 
-export { parseBCtoDSN, appendDSNRoll, roll, getCurrentEntity, getDataForCurrentEntity };
+export { parseBCtoDSN, appendDSNRoll, roll, getCurrentDocument, getDataForCurrentEntity };

--- a/scripts/macro-parser.js
+++ b/scripts/macro-parser.js
@@ -44,7 +44,7 @@ export default class MacroParser {
       escape(settings.headers?.start ?? "■") +
         "(.+?)" +
         escape(settings.headers?.end ?? "=") +
-        "+",
+        "*",
       "i"
     );
     const macro = new RegExp(

--- a/scripts/macro-parser.js
+++ b/scripts/macro-parser.js
@@ -3,7 +3,7 @@
  * @param {string} line
  * @returns string
  */
- function escape(line) {
+function escape(line) {
   return line.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
@@ -40,13 +40,16 @@ export default class MacroParser {
    */
   constructor(settings = {}) {
     this.settings = settings;
-    const header = new RegExp(
-      escape(settings.headers?.start ?? "■") +
-        "(.+?)" +
-        escape(settings.headers?.end ?? "=") +
-        "*",
-      "i"
-    );
+    let header;
+    if(settings.headers?.start !== '' || settings.headers?.end != '') {
+      // if any header setting exists, make regex
+      const headerStart = escape(settings.headers?.start ?? "■");
+      const headerEnd = escape(settings.headers?.end ?? "=");
+      header = new RegExp(`^${headerStart}(.+?)${headerEnd}*$`, 'i');
+    } else {
+      // if none exists, match nothing
+      header = new RegExp('a^');
+    }
     const macro = new RegExp(
       `(.*)${escape(settings.macro?.splitter ?? "▼")}(.*)`,
       "i"

--- a/styles/bcdice.css
+++ b/styles/bcdice.css
@@ -35,4 +35,4 @@
   overflow-y: scroll;
 }
 
-.window-content .dialog-content textarea{min-height:100px}
+.window-content .dialog-content textarea{min-height:145px}

--- a/templates/replacements.html
+++ b/templates/replacements.html
@@ -2,6 +2,6 @@
   <label>
     {{localize "fvtt-bcdice.replacementsHeader"}}
   </label>
-  <div>{{localize "fvtt-bcdice.replacementsTextHint"}}</div>
+  <p>{{localize "fvtt-bcdice.replacementsTextHint"}}</p>
   <textarea name="replacements">{{replacements}}</textarea>
 </div>


### PR DESCRIPTION
* Upping mayor version as this is not backward-compatible with versions < V9
* Fixed sidebar icon
* Updated keybindings to use the new Keybindings API
* Added `Formula Persistance` module setting for configuring if the roller should remain after a roll
* Fixed `Roller Persistance` module setting that was present but not working
* Bugfix that prevented the Roll button to work on the first click after changing the formula input
* Bugfix that prevented headers ### ■ that had no header trim values from working.

* Bugfix where header line parsing was not using start-of-string ^ nor end-of-string $ anchors that caused some incorrect parsing
* Bugfix for importing without any header start nor trim not sending values to Default Header as expected.